### PR TITLE
Fix date picker to show arrows

### DIFF
--- a/app/styles/styles.scss
+++ b/app/styles/styles.scss
@@ -2783,3 +2783,25 @@ global-filters {
 //       padding-bottom: 0;
 //     }
 // }
+
+// Overloading "glyphicon" class with "fa".
+.glyphicon {
+
+  @extend .fa;
+
+  &.glyphicon-chevron-left {
+      @extend .fa-chevron-left;
+  }
+
+  &.glyphicon-chevron-right {
+      @extend .fa-chevron-right;
+  }
+
+  &.glyphicon-chevron-up {
+    @extend .fa-chevron-up;
+  }
+
+  &.glyphicon-chevron-down {
+    @extend .fa-chevron-down;
+  }
+}


### PR DESCRIPTION
This is a cherry picked from [Språkbanken’s Korp frontend code](https://github.com/spraakbanken/korp-frontend/commit/36e828f3) to fix the date picker to show arrows when selecting a date interval, overloading `glyphicon` with `fa` for `datepicker` (see spraakbanken#266).

This should be merged along with merging the configuration branch [`config/t-fix-date-interval-chooser`](https://github.com/CSCfi/Kielipankki-korp-frontend/tree/config/t-fix-date-interval-chooser) to `config/master` to fix the date interval chooser.