### PR TITLE
KP-9048 Fix reittidemo video not found

### DIFF
--- a/app/modes/default_mode.js
+++ b/app/modes/default_mode.js
@@ -9968,7 +9968,7 @@ settings.corpora.reittidemo = {
     },
     customAttributes: {
         video: funcs.makeVideoAttr({
-            baseURL: "http://localhost/corpusdata/",
+            baseURL: "/media/",
             path: "reittidemo/",
             file: "reitti_a-siipeen",
             ext: "mp4",
@@ -16832,7 +16832,7 @@ funcs.addCorpusAliases(
     [
         "ylenews-fi-2019-2021-s-korp",
     ]);
-    
+
 funcs.addCorpusAliases(
     "ylenews_fi_20(1[1-9]|2[01])_s",
     [


### PR DESCRIPTION
The video file was not found from the specified location on korp2, and the localhost request made from a user's machine has likely never worked anyway. Now the config matches the location of the actual file.