### PR TITLE
Modifications to make ScotsCorr work in Korp 9

### DIFF
--- a/app/scripts/model.js
+++ b/app/scripts/model.js
@@ -34,12 +34,16 @@ class BaseProxy {
     }
 
     expandCQP(cqp) {
+        let result
         try {
-            return CQP.expandOperators(cqp)
+            result = CQP.expandOperators(cqp)
         } catch (e) {
             c.warn("CQP expansion failed", cqp, e)
-            return cqp
+            result = cqp
         }
+        // Let plugins filter the expanded CQP
+        result = plugins.callFilters("filterExpandedCQP", result)
+        return result
     }
 
     makeRequest() {

--- a/app/scripts/search_controllers.js
+++ b/app/scripts/search_controllers.js
@@ -455,6 +455,8 @@ korpApp.controller("ExtendedSearch", function ($scope, $location, $rootScope, se
         if ($rootScope.globalFilter) {
             val2 = CQP.stringify(CQP.mergeCqpExprs(CQP.parse(val2 || "[]"), $rootScope.globalFilter))
         }
+        // Let plugins filter the extended search CQP expression
+        val2 = plugins.callFilters("filterExtendedCQP", val2)
         $rootScope.extendedCQP = val2
     }
 
@@ -488,6 +490,8 @@ korpApp.controller("ExtendedSearch", function ($scope, $location, $rootScope, se
     return s.$on("corpuschooserchange", function () {
         s.withins = s.getWithins()
         s.within = s.withins[0] && s.withins[0].value
+        // Let plugins act when corpus selection is changed
+        plugins.callActions("onCorpusChooserChange")
     })
 })
 

--- a/app/scripts/util.js
+++ b/app/scripts/util.js
@@ -31,6 +31,8 @@ window.CorpusListing = class CorpusListing {
             "getStructAttrsIntersection",
             "getStructAttrs",
         ])
+        // Let plugins act on CorpusListing after constructing it
+        plugins.callActions("onCorpusListingConstructed", this)
     }
 
     get(key) {
@@ -63,6 +65,9 @@ window.CorpusListing = class CorpusListing {
 
     select(idArray) {
         this.selected = _.values(_.pick.apply(this, [this.struct].concat(idArray)))
+        // Let plugins act on CorpusListing when selecting the corpora
+        // listed in idArray
+        plugins.callActions("onCorpusListingSelect", this, idArray)
     }
 
     mapSelectedCorpora(f) {

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -417,6 +417,11 @@ module.exports = {
                     noErrorOnMissing: true,
                 },
                 {
+                    from: korpConfigDir + "/corpus_info/*.json",
+                    to: "corpus_info/[name].[ext]",
+                    noErrorOnMissing: true,
+                },
+                {
                     from: "app/translations/angular-locale_*.js",
                     to: "translations/[name].[ext]",
                 },


### PR DESCRIPTION
These changes are needed to make ScotsCorr work in Korp 9, along with changes in the backend, frontend plugins and frontend configuration:

- Copy files from the `corpus_info` directory in the configuration to the corresponding location in Webpack, needed for the ScotsCorr word list.
- Add a number of plugin hook points for the plugin `cqp_between_tokens`, used by ScotsCorr (and LA-murre and ELFA).