### PR TITLE
ExtendedSearch controller: Pass updateExtendedCQP to plugins

### DIFF
--- a/app/scripts/search_controllers.js
+++ b/app/scripts/search_controllers.js
@@ -490,8 +490,11 @@ korpApp.controller("ExtendedSearch", function ($scope, $location, $rootScope, se
     return s.$on("corpuschooserchange", function () {
         s.withins = s.getWithins()
         s.within = s.withins[0] && s.withins[0].value
-        // Let plugins act when corpus selection is changed
-        plugins.callActions("onCorpusChooserChange")
+        // Let plugins act when corpus selection is changed; pass
+        // updateExtendedCQP as an argument so that a plugin may call
+        // it if the extended CQP needs updating because of the plugin
+        plugins.callActions("onCorpusChooserChange",
+                            {updateExtendedCQP: updateExtendedCQP})
     })
 })
 


### PR DESCRIPTION
`ExtendedSearch` controller: `corpuschooserchange` event: Pass function `updateExtendedCQP` as an argument to plugins for the hook point `onCorpusChooserChange`, so that a plugin may call it if the extended CQP needs updating because of the plugin.

This allows allows the CQP expression shown in the advanced search for the extended search to reflect the possible change in `ignoreBetweenTokensCQP` caused by a change in selected corpora (see commit 8a84d972 in branch [`plugins/master`](https://github.com/CSCfi/Kielipankki-korp-frontend/tree/plugins/master)).