### PR TITLE
Fix escaping backslashes in extended search

### DIFF
--- a/app/scripts/util.js
+++ b/app/scripts/util.js
@@ -1055,9 +1055,17 @@ util.loadCorpora = function () {
     settings.corpusListing.select(selected)
 }
 
-window.regescape = (s) => s.replace(/[.|?|+|*||'|()^$]/g, "\\$&").replace(/"/g, '""')
+window.regescape = (s) => s.replace(/[.|?|+|*||'|()^$\\]/g, "\\$&").replace(/"/g, '""')
 
-window.unregescape = (s) => s.replace(/\\/g, "").replace(/""/g, '"')
+window.unregescape = (s) =>
+    // remove single backslashes and replace double backslashes with one backslash
+    s.replace(/\\\\|\\/g, (match) => {
+        if (match === "\\\\") {
+            return "\\"
+        } else {
+            return ""
+        }
+    })
 
 util.formatDecimalString = function (x, mode, statsmode, stringOnly) {
     if (_.includes(x, ".")) {


### PR DESCRIPTION
This is a cherry picked from [Språkbanken’s Korp frontend code](https://github.com/spraakbanken/korp-frontend/commit/375e202b) to fix escaping backslashes in values entered in the extended search (see spraakbanken#316) so that such values can be searched without specifying them as a regular expression.