### PR TITLE
KP-9232 annlab sunset

### DIFF
--- a/app/includes/main_menu.pug
+++ b/app/includes/main_menu.pug
@@ -26,16 +26,6 @@ li#korplink(class=locals.cls_mainmenu_li)
     class=locals.cls_mainmenu_a
     ng-href="{{makeKorpUrl('main')}}"
   ) {{'korp' | loc:lang}}
-li#korplablink(class=locals.cls_mainmenu_li)
-  a(
-    class=locals.cls_mainmenu_a
-    ng-href="{{makeKorpUrl('lab')}}"
-  ) {{'korp_lab' | loc:lang}}
-li#korpoldlink(class=locals.cls_mainmenu_li)
-  a(
-    class=locals.cls_mainmenu_a
-    ng-href="{{makeKorpUrl('old')}}"
-  ) {{'korp_old' | loc:lang}}
 li#import(class=locals.cls_mainmenu_li)
   a(
     class=locals.cls_mainmenu_a

--- a/app/includes/main_menu.pug
+++ b/app/includes/main_menu.pug
@@ -39,9 +39,9 @@ li#korpoldlink(class=locals.cls_mainmenu_li)
 li#import(class=locals.cls_mainmenu_li)
   a(
     class=locals.cls_mainmenu_a
-    href='https://www.kielipankki.fi/korp/cgi-bin/annlab/parse'
+    href='https://www.kielipankki.fi/tools/demo/cgi-bin/finparse.py'
     target='_blank'
-  ) {{'import_chain' | loc:lang}}
+  ) {{'parsing_demo' | loc:lang}}
 li(class=locals.cls_mainmenu_li)
   a(
     class=locals.cls_mainmenu_a

--- a/app/translations/locale-en.json
+++ b/app/translations/locale-en.json
@@ -10,7 +10,7 @@
     "feedback_link": "<a id='feedback' class='follow_link' href='https://elomake.helsinki.fi/lomakkeet/56593/lomake.html?rinnakkaislomake=korpfeedback' target='_blank'>Feedback</a>",
     "feedback_url": "https://elomake.helsinki.fi/lomakkeet/56593/lomake.html?rinnakkaislomake=korpfeedback",
     "feedback_linktext": "Feedback",
-    "import_chain": "Annotation Lab",
+    "parsing_demo": "Parse some Finnish text",
     "annotlab_multilingual": "Multilingual Annotation Lab (Sparv)",
     "annotlab_multilingual_url_params": "lang=en&language=en",
     "privacy": "Privacy policy",

--- a/app/translations/locale-fi.json
+++ b/app/translations/locale-fi.json
@@ -91,7 +91,7 @@
     "send": "Lähetä",
     "log_out": "Kirjaudu ulos",
     "strict": "tarkka",
-    "import_chain": "Annotointilaboratorio",
+    "parsing_demo": "Jäsennä omaa tekstiä",
     "show_deptree": "Näytä dependenssipuu",
     "dep_tree": "Dependenssipuu",
     "download": "Lataa tiedostona muodossa:",

--- a/app/translations/locale-sv.json
+++ b/app/translations/locale-sv.json
@@ -10,7 +10,7 @@
     "feedback_link": "<a id='feedback' class='follow_link' href='https://elomake.helsinki.fi/lomakkeet/56593/lomake.html?rinnakkaislomake=korpfeedback_sv' target='_blank'>Feedback</a>",
     "feedback_url": "https://elomake.helsinki.fi/lomakkeet/56593/lomake.html?rinnakkaislomake=korpfeedback_sv",
     "feedback_linktext": "Feedback",
-    "import_chain": "Annoteringslabbet",
+    "parsing_demo": "Annoteringsverktyg för finska",
     "annotlab_multilingual": "Flerspråkiga annoteringslabbet (Sparv)",
     "annotlab_multilingual_url_params": "lang=sv&language=sv",
     "privacy": "Dataskyddsbeskrivning",


### PR DESCRIPTION
Remove links to Annlab in the "cog" (now hamburger) menu, and also a few defunct korp.csc.fi links. Link instead to the tool demo server's annotation service (improvements to which are forthcoming).