### PR TITLE
Sidebar: Show a hidden label for an empty value; attribute-specific empty value

### DIFF
--- a/app/scripts/components/sidebar.js
+++ b/app/scripts/components/sidebar.js
@@ -314,7 +314,11 @@ export const sidebarComponent = {
                     }
 
                     output.data("attrs", attrs)
-                    if (value === "|" || value === "" || value === null) {
+                    // attrs.emptyValue can be used to specify an
+                    // attribute-specific value represented as
+                    // "[empty]"
+                    if (value === "|" || value === "" || value === null
+                            || value === attrs.emptyValue) {
                         output.append(
                             `<i rel='localize[empty]' style='color : grey'>${util.getLocaleString("empty")}</i>`
                         )

--- a/app/scripts/components/sidebar.js
+++ b/app/scripts/components/sidebar.js
@@ -319,6 +319,13 @@ export const sidebarComponent = {
                     // "[empty]"
                     if (value === "|" || value === "" || value === null
                             || value === attrs.emptyValue) {
+                        // If the label is hidden but the value is
+                        // empty, show the label anyway, so that the
+                        // user can see what is empty
+                        if (attrs.label && attrs.sidebarHideLabel) {
+                            output.append(
+                                `<span rel='localize[${attrs.label}]'></span>: `)
+                        }
                         output.append(
                             `<i rel='localize[empty]' style='color : grey'>${util.getLocaleString("empty")}</i>`
                         )


### PR DESCRIPTION
Make two minor enhancements to displaying empty values in the sidebar:

1. Show a label for an empty value even if the label is usually hidden. This is relevant primarily for links where the label is the link text: previously, they would be shown simply as “_[empty]_”, with no label and thus no indication of what is empty; now they are shown as “label: _[empty]_”.
2. Support property `emptyValue` in attribute configurations to specify a value which is shown as “_[empty]_“, in addition to a completely empty value. This can be used if e.g. the underscore is used to denote an empty value.

The first feature is in use in the [Korp test instance for Achemenet and BALT](https://www.kielipankki.fi/staging/korp/jn/achemenet/?mode=other_languages#?corpus=achemenet,balt&lang=en), but the second one is not currently used.