### PR TITLE
Fix extended search attribute selector to show attributes only once

### DIFF
--- a/app/scripts/util.js
+++ b/app/scripts/util.js
@@ -477,6 +477,7 @@ window.CorpusListing = class CorpusListing {
     getAttributeGroups(lang) {
         const words = this.getWordGroup(false)
         const attrs = this.getWordAttributeGroups(lang, "union")
+        this._adjustWordAttributeGroup(words, attrs)
         const sentAttrs = this.getStructAttributeGroups(lang, "union")
         return words.concat(attrs, sentAttrs)
     }
@@ -486,12 +487,30 @@ window.CorpusListing = class CorpusListing {
 
         const wordOp = settings.reduceWordAttributeSelector || "union"
         const attrs = this.getWordAttributeGroups(lang, wordOp)
+        this._adjustWordAttributeGroup(words, attrs)
 
         const structOp = settings.reduceStructAttributeSelector || "union"
         const sentAttrs = this.getStructAttributeGroups(lang, structOp)
 
         return words.concat(attrs, sentAttrs)
     }
+
+    // If word attribute group attrs contains "word", effectively move
+    // it (the first one only) to the word group words, to avoid
+    // duplicating "word" in both word and word attribute group. To
+    // preserve possible extra features in the attribute "word", it is
+    // moved to the word group and not simply removed from the word
+    // attribute group.
+    _adjustWordAttributeGroup(words, attrs) {
+        const word_attr_num = _.findIndex(attrs, obj => obj.value === "word")
+        if (word_attr_num !== -1) {
+            const word_attr = attrs[word_attr_num]
+            word_attr.group = "word"
+            words[0] = word_attr
+            attrs.splice(word_attr_num, 1)
+        }
+    }
+
 }
 
 // TODO never use this, remove when sure it is not used

--- a/app/scripts/util.js
+++ b/app/scripts/util.js
@@ -31,6 +31,10 @@ window.CorpusListing = class CorpusListing {
             "getStructAttrsIntersection",
             "getStructAttrs",
         ])
+        // Names of word attributes, to help avoid having
+        // (intra-sentence structural) attributes both as word and
+        // text (structural) attributes
+        this._wordAttrNames = new Set()
         // Let plugins act on CorpusListing after constructing it
         plugins.callActions("onCorpusListingConstructed", this)
     }
@@ -436,6 +440,9 @@ window.CorpusListing = class CorpusListing {
                 attrs.push(_.extend({ group: "word_attr", value: key }, obj))
             }
         }
+        // Set this._wordAttrNames for the next call of
+        // this.getStructAttributeGroups
+        this._wordAttrNames = new Set(_.map(attrs, (corp) => corp.value))
         return attrs
     }
 
@@ -454,7 +461,10 @@ window.CorpusListing = class CorpusListing {
         const object = _.extend({}, common, allAttrs)
         for (let key in object) {
             const obj = object[key]
-            if (obj.displayType !== "hidden") {
+            // NOTE: The following assumes that this._wordAttrNames
+            // has been set in this.getWordAttributeGroups with the
+            // same value for setOperator as for this call
+            if (obj.displayType !== "hidden" && ! this._wordAttrNames.has(key)) {
                 sentAttrs.push(_.extend({ group: "sentence_attr", value: key }, obj))
             }
         }


### PR DESCRIPTION
Two commits to fix two cases of attributes shown twice in the Korp extended search attribute selection list:

1. Intra-sentence structural attributes, such as name attributes in `ne` structures, are now listed only under _Word attributes_, as in the sidebar. Previously, they were duplicated under _Text attributes_.

    This can be tested in [this Korp test instance](https://www.kielipankki.fi/staging/korp/jn/s24-2001-2023/#?lang=en&corpus=s24_2001&search_tab=1), where attributes such as _name_ and _named entity_ are listed only under _Word attributes_ in the attribute selection list.
    The previous behaviour can be seen in the [production Korp](https://www.kielipankki.fi/korp/#?&lang=en&corpus=s24_001&search_tab=1), where they are listed under both _Word attributes_ and _Text attributes_ (the corpus is different with partly different attributes).

2. The word form (_word_) is listed only as _word_ in the search and statistics attribute selection lists even if it the corpus configuration has an attribute definition for `word` that adds special features. Previously, _word_ was duplicated under _Word attributes_ in both search and statistics attribute selection lists if it had an attribute definition. This currently only affects the ScotsCorr corpus.

    This can be tested in [this Korp test instance](https://www.kielipankki.fi/staging/korp/jn/s24-2001-2023/?mode=other_languages#?lang=en&corpus=scots_royal&search_tab=1) (requires logging in and ACA access rights), where _word_ is listed only under _word_ in the attribute selection list.
    The previous behaviour can be seen in the [production Korp](https://www.kielipankki.fi/korp/?mode=other_languages#?lang=en&corpus=scots_royal&cqp=%5B%5D&search_tab=1) where _word_ is listed both under _word_ and _Word attributes_, in both the search and statistics attribute selection lists.

    Note that this would not work as intended if the selected corpora had several different attribute definitions for `word`. This is currently not a problem as ScotsCorr is the only corpus with special features for `word`, and even otherwise, you probably should not select two corpora with different special features for `word`.