### PR TITLE
Plugin `config_augment_info`: Support localizing values added to corpus title

### DIFF
--- a/app/plugins/config_augment_info/scripts/main.js
+++ b/app/plugins/config_augment_info/scripts/main.js
@@ -47,6 +47,10 @@ class ConfigInfoAugmenter {
         // feature "corpusInfo", so that the properties have been
         // propagated from corpus folders to individual corpora.
         this.requiresFeatures = ["corpusInfo"]
+        // Localization function for description
+        this._localize = {
+            description: (locKey) => `<span rel="localize[$locKey]">${util.getLocaleString(locKey)}</span>`,
+        }
     }
 
     // Initialize by adding default augmentTitle and
@@ -120,19 +124,31 @@ class ConfigInfoAugmenter {
                                 propSpec.values.includes(value)) {
                             target.title = propSpec.augmentTitle(
                                 target.title, value)
-                            if (propSpec.localizeDescription) {
-                                let locKey =
-                                    `corpusinfo_descr_${propName}_${value}`
-                                value = `<span rel="localize[$locKey]">${util.getLocaleString(locKey)}</span>`
-                            }
-                            target.description = propSpec.augmentDescription(
-                                target.description, value)
+                            target.description = this._augmentProp(
+                                target, "description", propSpec, propName,
+                                value)
                         }
                     }
                 }
                 // TODO: Add support for boolean properties
             }
         }
+    }
+
+    // Return target[targetPropName] (title or description of corpus
+    // or folder cnfiguration) augmented as specified in propSpec for
+    // property propName with value.
+    _augmentProp (target, targetPropName, propSpec, propName, value) {
+        const targetPropNameCap =
+              targetPropName.replace(/^./, (x) => x.toUpperCase())
+        const targetPropNameShort = targetPropName.slice(0, 5)
+        if (propSpec["localize" + targetPropNameCap]) {
+            const locKey =
+                  `corpusinfo_${targetPropNameShort}_${propName}_${value}`
+            value = this._localize[targetPropName](locKey)
+        }
+        return propSpec["augment" + targetPropNameCap](target[targetPropName],
+                                                       value)
     }
 
 }

--- a/app/plugins/config_augment_info/scripts/main.js
+++ b/app/plugins/config_augment_info/scripts/main.js
@@ -16,8 +16,12 @@
 //   only supported value is "stringlist": an array of string values
 //   or a string of values separated by commas or spaces
 // - values: an array of string supported values for property
+// - localizeTitle: if true, localize the title using translation key
+//   corpusinfo_title_<property>_<value> (this localization is not
+//   dynamic: the language is changed only when switching modes or
+//   reloading the Korp page)
 // - localizeDescription: if true, localize the description using
-//   translation key corpusinfo_descr_<property>_<value>
+//   translation key corpusinfo_descr_<property>_<value> (not dynamic)
 // - augmentTitle: function (title, value): add value to existing
 //   title (default: append value in parentheses)
 // - augmentDescription: function (description, value): add value to
@@ -47,8 +51,9 @@ class ConfigInfoAugmenter {
         // feature "corpusInfo", so that the properties have been
         // propagated from corpus folders to individual corpora.
         this.requiresFeatures = ["corpusInfo"]
-        // Localization function for description
+        // Localization function for title and description
         this._localize = {
+            title: (locKey) => util.getLocaleString(locKey),
             description: (locKey) => `<span rel="localize[$locKey]">${util.getLocaleString(locKey)}</span>`,
         }
     }
@@ -122,11 +127,11 @@ class ConfigInfoAugmenter {
                         // the value is not one of them
                         if (! propSpec.values ||
                                 propSpec.values.includes(value)) {
-                            target.title = propSpec.augmentTitle(
-                                target.title, value)
-                            target.description = this._augmentProp(
-                                target, "description", propSpec, propName,
-                                value)
+                            for (let targetProp of ["title", "description"]) {
+                                target[targetProp] = this._augmentProp(
+                                    target, targetProp, propSpec, propName,
+                                    value)
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Add to plugin [`config_augment_info`](https://github.com/CSCfi/Kielipankki-korp-frontend/blob/plugins/config-augment-info-localize-title/app/plugins/config_augment_info/scripts/main.js) support for localizing values added to the corpus title, in addition to the description. Localization is enabled by specifying the property `localizeTitle: true` in the configurable property and by specifying translations with keys `corpusinfo_title_`_property_`_`_value_` for the value _value_ of a configurable property _property_.

This is currently used for the corpus status (e.g. _release candidate_) and can be seen in work in [this Korp test instance](https://www.kielipankki.fi/staging/korp/jn/s24-2001-2023/) where the Suomi24 corpora have a release candidate status marked with a localized text appended to the corpus name in brackets. The corresponding change is in commit b8e65ff48.

Note that the localization is _not_ dynamic: it does not change immediately when switching UI languages in Korp but only when after reloading the page or switching Korp modes.