### PR TITLE
News on Suomi24 2001–2023 (and “release candidate” replacing “beta”)

### DIFF
--- a/korp/en.txt
+++ b/korp/en.txt
@@ -1,5 +1,5 @@
 
-<!-- Extended and updated corpus collection (release candidate): Suomi24 2001–2023 2025-04-08b -->
+<!-- Extended and updated corpus collection (release candidate): Suomi24 2001–2023 2025-04-10b -->
 
 <a href="http://urn.fi/urn:nbn:fi:lb-2024051601" target="_blank"
 title="metadata">The Suomi24 Sentences Corpus 2001–2023, Korp

--- a/korp/en.txt
+++ b/korp/en.txt
@@ -1,4 +1,36 @@
 
+<!-- Extended and updated corpus collection (release candidate): Suomi24 2001–2023 2025-04-08b -->
+
+<a href="http://urn.fi/urn:nbn:fi:lb-2024051601" target="_blank"
+title="metadata">The Suomi24 Sentences Corpus 2001–2023, Korp
+version</a> is now available in Korp as a release candidate.
+
+The collection has been extended with the discussions of 2021–2023 (<a
+href="http://urn.fi/urn:nbn:fi:lb-2024030601" target="_blank"
+title="metadata">The Suomi24 Sentences Corpus 2021–2023, Korp
+version</a>), with over 15 million messages (texts) and nearly 474
+million tokens. Word pictures for these years will be available once
+the word picture data has been completely loaded to the database.
+
+In addition, the Suomi24 Sentences Corpora <a
+href="http://urn.fi/urn:nbn:fi:lb-2020021803" target="_blank"
+title="metadata">2001–2017</a> and <a
+href="http://urn.fi/urn:nbn:fi:lb-2021101521" target="_blank"
+title="metadata">2018–2020</a> have been updated with annotations of
+names recognized with <a href="http://urn.fi/urn:nbn:fi:lb-2024021401"
+target="_blank" title="metadata">FiNER 1.6</a> and languages of
+sentences identified with <a
+href="http://urn.fi/urn:nbn:fi:lb-2024040301" target="_blank"
+title="metadata">HeLI-OTS 2.0</a>. In addition, spurious spaces have
+been removed from topic names, titles and author nicknames in these
+corpora. Because of these additions and changes, the version numbers
+of the older parts have been incremented and the new versions are
+release candidates.
+
+<a href="http://urn.fi/urn:nbn:fi:lb-2025040201"
+target="_blank">More details on the changes.</a>
+
+
 <!-- Publishing convention update: release candidate 2025-04-08a -->
 
 In the future, a new or significantly updated language resource to be

--- a/korp/en.txt
+++ b/korp/en.txt
@@ -1,4 +1,22 @@
 
+<!-- Publishing convention update: release candidate 2025-04-08a -->
+
+In the future, a new or significantly updated language resource to be
+published in the Language Bank of Finland (Kielipankki) is first a
+_release candidate_, which is more descriptive than the previously
+used _beta test version_. In Korp, this status is suffixed in brackets
+to the corpus name, and the description of the corpus contains the
+additional text “Please note that the corpus is a release candidate,
+so it may still change”.
+
+If no needs for corrections or other changes to the release candidate
+are detected typically within approximately two weeks after publishing
+it, it will become the final published version as such. If the release
+candidate is changed, users are informed of the changes and a new
+release candidate version is published that will be as a release
+candidate again for approximately two weeks.
+
+
 <!-- New Cuneiform corpora (beta): Achemenet and BALT 2025-03-18 -->
 
 Two new Cuneiform corpora are now available in Korp as beta test

--- a/korp/fi.txt
+++ b/korp/fi.txt
@@ -1,4 +1,36 @@
 
+<!-- Laajennettu ja päivitetty aineistokokoelma (julkaisuehdokas): Suomi24 2001–2023 2025-04-08b -->
+
+Korpissa on nyt käytettävissä julkaisuehdokasversiona <a
+href="http://urn.fi/urn:nbn:fi:lb-2024051601" target="_blank"
+title="kuvailutiedot">Suomi24 virkkeet -korpus 2001–2023,
+Korp-versio</a>.
+
+Kokoelmaan on lisätty uutena osana vuosien 2021–2023 keskustelut (<a
+href="http://urn.fi/urn:nbn:fi:lb-2024030601" target="_blank"
+title="kuvailutiedot">Suomi24 virkkeet -korpus 2021–2023,
+Korp-versio</a>), jossa on yhteensä yli 15 miljoonaa viestiä (tekstiä)
+ja lähes 474 miljoonaa sanetta. Näiden vuosien sanakuvat tulevat
+saataville, kun sanakuvadata on kokonaan ladattu tietokantaan.
+
+Lisäksi myös vuosien <a href="http://urn.fi/urn:nbn:fi:lb-2020021803"
+target="_blank">2001–2017</a> ja <a
+href="http://urn.fi/urn:nbn:fi:lb-2021101521"
+target="_blank">2018–2020</a> aineistoihin on merkitty <a
+href="http://urn.fi/urn:nbn:fi:lb-2024021401" target="_blank"
+title="kuvailutiedot">FiNER 1.6 -nimientunnistimella</a> tunnistetut
+nimet ja <a href="http://urn.fi/urn:nbn:fi:lb-2024040301"
+target="_blank" title="kuvailutiedot">HeLI-OTS 2.0
+-kielentunnistimella</a> tunnistetut virkkeiden kielet. Näissä
+aineistoissa on myös poistettu ylimääräisiä välilyöntejä aihealueista,
+otsikoista ja kirjoittajien nimimerkeistä. Näiden lisäysten ja
+muutosten vuoksi vanhempien osien versionumeroita on kasvatettu ja
+uudet versiot ovat julkaisuehdokkaita.
+
+<a href="http://urn.fi/urn:nbn:fi:lb-2025040201"
+target="_blank">Tarkempia tietoja muutoksista</a> (englanniksi).
+
+
 <!-- Julkaisukäytännön päivitys: julkaisuehdokas 2025-04-08a -->
 
 Jatkossa Kielipankissa julkaistava uusi tai merkittävästi päivitetty

--- a/korp/fi.txt
+++ b/korp/fi.txt
@@ -1,4 +1,21 @@
 
+<!-- Julkaisukäytännön päivitys: julkaisuehdokas 2025-04-08a -->
+
+Jatkossa Kielipankissa julkaistava uusi tai merkittävästi päivitetty
+aineisto on aluksi _julkaisuehdokas_ (_release candidate_), joka kuvaa
+aineiston tilaa paremmin kuin aiemmin käytetty _beetatestiversio_.
+Korpissa tämä on merkitty aineiston nimen perään sulkeissa, ja
+aineiston kuvauksessa on lisäteksti ”Huomaa, että korpus on
+julkaisuehdokas, joten siihen voi vielä tulla muutoksia”.
+
+Jos julkaisuehdokkaassa ei havaita korjaus- tai muutostarpeita
+tyypillisesti noin kahden viikon sisällä sen julkaisemisesta, siitä
+tulee sellaisenaan lopullinen julkaistu versio. Jos
+julkaisuehdokkaaseen tehdään muutoksia, niistä tiedotetaan ja
+aineistosta tulee uusi julkaisuehdokasversio, joka on
+julkaisuehdokkaana jälleen noin kaksi viikkoa.
+
+
 <!-- Uusia nuolenpääkirjoitusaineistoja (beta): Achemenet ja BALT 2025-03-18 -->
 
 Korpissa on nyt käytettävissä beetatestiversiona kaksi uutta

--- a/korp/fi.txt
+++ b/korp/fi.txt
@@ -1,5 +1,5 @@
 
-<!-- Laajennettu ja päivitetty aineistokokoelma (julkaisuehdokas): Suomi24 2001–2023 2025-04-08b -->
+<!-- Laajennettu ja päivitetty aineistokokoelma (julkaisuehdokas): Suomi24 2001–2023 2025-04-10b -->
 
 Korpissa on nyt käytettävissä julkaisuehdokasversiona <a
 href="http://urn.fi/urn:nbn:fi:lb-2024051601" target="_blank"

--- a/korp/sv.txt
+++ b/korp/sv.txt
@@ -1,3 +1,23 @@
+
+<!-- Uppdatering av publikationspraxis: releasekandidat 2025-04-07a -->
+
+I fortsättningen ska en ny eller betydligt uppdaterad språkresurs som
+publiceras i Språkbanken i Finland (Kielipankki) först vara en
+_releasekandidat_ (_release candidate_, _leveransversionkandidat_),
+som beskriver korpusens tillstånd bättre än _betatestversion_ som
+använts förr. I Korp är tillståndet märkt inom parentes efter
+korpusens namn, och korpusens beskrivning har tilläggstexten
+”Observera att korpusen är en releasekandidat, så den kan fortfarande
+ändras”.
+
+Om inga behov för korrigeringar eller andra ändringar till en
+releasekandidat märks typiskt inom ungefär två veckor efter dess
+publicering, releasekandidaten blir den slutliga publicerade version
+som den är. Om releasekandidaten ändras, Korps användare informeras om
+ändringarna och det publiceras en ny releasekandidatversion som är
+releasekandidat igen för ungefär två veckor.
+
+
 <!-- Nedlagda funktioner tagits bort eller ersatts 2024-12-28 -->
 
 Hamburgermenyn i det övre högra hörnet hade tidigare länkar till


### PR DESCRIPTION
Korp news on Suomi 2001–2023 and the term “release candidate” replacing “beta” in the publication process.