### PR TITLE
suomi24-2001-2023 (accruing): Remove release candidate status

### DIFF
--- a/app/modes/default_mode.js
+++ b/app/modes/default_mode.js
@@ -356,7 +356,6 @@ settings.corporafolders.cmc.suomi24_accruing = {
             name: "City Digital",
             url: "https://www.citydigital.fi/",
         },
-        status: "rc",
     }
 };
 


### PR DESCRIPTION
Remove the release candidate status from the [Suomi24 2001–2023 corpus](http://urn.fi/urn:nbn:fi:lb-2024051601) in Korp.

The configuration can be seen in work in [this Korp test instance](https://www.kielipankki.fi/staging/korp/jn/s24-2001-2023/#?corpus=suomi24-2001-2023): the corpus names do not have the suffix “(julkaisuehdokas)” / “(release candidate)”.