### PR TITLE
Configuration: Swedish: Fix base forms to work in extended search

### DIFF
--- a/app/modes/common.js
+++ b/app/modes/common.js
@@ -3795,7 +3795,7 @@ attrs.msd_sv = {
 attrs.baseform_sv = {
     label: "baseform",
     type: "set",
-    opts: options.default,
+    opts: options.fullSet,
     extendedTemplate: "<input ng-model='model' >",
     order: 1
 };


### PR DESCRIPTION
Fix base forms in Swedish corpora to work in the extended search by replacing `options.default` with `options.fullSet` in `attrs.baseform_sv` (`app/modes/common.js`).

`options.default` only works for single-valued attributes (using operator `=`) but the Swedish base forms are set-valued (requiring operator `contains`). Thus, before this fix, including a base form in the extended search gave always an empty result for Swedish corpora. This bug had been present for many years, perhaps from the very beginning.