### PR TITLE
Support corpus status “rc2” (release candidate 2)

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -927,6 +927,7 @@ settings.augmentCorpusInfoProperties = {
         values: [
             "beta",
             "rc",
+            "rc2",
             "test",
         ],
         localizeTitle: true,

--- a/app/translations/locale-en.json
+++ b/app/translations/locale-en.json
@@ -25,6 +25,8 @@
 
     "corpusinfo_title_status_rc": "release candidate",
     "corpusinfo_descr_status_rc": "<strong>Please note</strong> that the corpus is a release candidate, so it may still change.",
+    "corpusinfo_title_status_rc2": "release candidate 2",
+    "corpusinfo_descr_status_rc2": "<strong>Please note</strong> that the corpus is a release candidate, so it may still change.",
     "corpusinfo_title_status_beta": "beta",
     "corpusinfo_descr_status_beta": "<strong>Please note</strong> that the corpus is in beta testing, so it may change without notice.",
     "corpusinfo_title_status_test": "test",

--- a/app/translations/locale-fi.json
+++ b/app/translations/locale-fi.json
@@ -483,6 +483,8 @@
 
     "corpusinfo_title_status_rc": "julkaisuehdokas",
     "corpusinfo_descr_status_rc": "<strong>Huomaa</strong>, että korpus on julkaisuehdokas, joten siihen voi vielä tulla muutoksia.",
+    "corpusinfo_title_status_rc": "julkaisuehdokas 2",
+    "corpusinfo_descr_status_rc": "<strong>Huomaa</strong>, että korpus on julkaisuehdokas, joten siihen voi vielä tulla muutoksia.",
     "corpusinfo_title_status_beta": "beeta",
     "corpusinfo_descr_status_beta": "<strong>Huomaa</strong>, että korpus on beetatestivaiheessa, joten siihen voi tulla muutoksia ilman ilmoitusta.",
     "corpusinfo_title_status_test": "testi",

--- a/app/translations/locale-sv.json
+++ b/app/translations/locale-sv.json
@@ -25,6 +25,8 @@
 
     "corpusinfo_title_status_rc": "releasekandidat",
     "corpusinfo_descr_status_rc": "<strong>Observera</strong> att korpusen är en releasekandidat, så den kan fortfarande ändras.",
+    "corpusinfo_title_status_rc2": "releasekandidat 2",
+    "corpusinfo_descr_status_rc2": "<strong>Observera</strong> att korpusen är en releasekandidat, så den kan fortfarande ändras.",
     "corpusinfo_title_status_beta": "beta",
     "corpusinfo_descr_status_beta": "<strong>Observera</strong> att korpusen betatestas, så den kan ändras utan förvarning.",
     "corpusinfo_title_status_test": "test",


### PR DESCRIPTION
Add support for marking a corpus as being ”release candidate 2” (`status: "rc2"` in the corpus configuration).